### PR TITLE
Fix check whether update was successful

### DIFF
--- a/syno.plexupdate.sh
+++ b/syno.plexupdate.sh
@@ -280,6 +280,7 @@ if [ "$?" -eq "0" ]; then
     printf "%s\n" "----------------------------------------"
     printf "\n"
     NowVersion=$(/usr/syno/bin/synopkg version "Plex Media Server")
+    NowVersion=$(echo $NowVersion | grep -oP '^.+?(?=\-)')
     printf "%16s %s\n"      "Update from:" "$RunVersion"
     printf "%16s %s"                 "to:" "$NewVersion"
 


### PR DESCRIPTION
In commit 2b4d78f the current and new versions were trimmed of their build number. This was updated for the current and new versions, but missed for the `$NowVersion` (the version post-installation). This unfortunately broke the success check because the non-trimmed `$NowVersion` was considered greater than the trimmed `$RunVersion`.