### PR TITLE
#26 GitHub Release relative-time bugfix

### DIFF
--- a/syno.plexupdate.sh
+++ b/syno.plexupdate.sh
@@ -70,7 +70,7 @@ if [ "$?" -eq "0" ]; then
   SPUSZipLnk=https://github.com/$(echo $SPUSRelHtm | grep -oP '\<title\>Release v\d{1,}\.\d{1,}(\.\d{1,})?(\.\d{1,})?')
   SPUSZipFil=${SPUSZipLnk##*/}
   SPUSZipVer=$(echo $SPUSZipFil | grep -oP '\d{1,}\.\d{1,}\.\d{1,}')
-  SPUSGtDate=$(echo $SPUSRelHtm | grep -oP 'relative-time datetime="\K[^"]+')
+  SPUSGtDate=$(echo $SPUSRelHtm | grep -oP 'relative-time datetime="\K[^"]+' | head -1)
   SPUSRlDate=$(date --date "$SPUSGtDate" +'%s')
   SPUSRelAge=$((($TodaysDate-$SPUSRlDate)/86400))
   SPUSDwnUrl=https://raw.githubusercontent.com/michealespinola/syno.plexupdate/v$SPUSZipVer/syno.plexupdate.sh


### PR DESCRIPTION
The grep is returning multiple results, we can resolve this with  `head -1`

Quick Proof:

```
NetTimeout=30

echo "Old"
SPUSRelHtm=$(curl -m $NetTimeout -L -s https://github.com/michealespinola/syno.plexupdate/releases/latest)
SPUSGtDate=$(echo $SPUSRelHtm | grep -oP 'relative-time datetime="\K[^"]+')
SPUSRlDate=$(date --date "$SPUSGtDate" +'%s')
echo $SPUSGtDate
echo $SPUSRlDate

echo "New"
SPUSGtDate=$(echo $SPUSRelHtm | grep -oP 'relative-time datetime="\K[^"]+' | head -1)
SPUSRlDate=$(date --date "$SPUSGtDate" +'%s')
echo $SPUSGtDate
echo $SPUSRlDate


```

Output:

![image](https://user-images.githubusercontent.com/13224936/171253189-a918b972-cb78-4ce1-81b5-a7ff202c8162.png)

Resolves #26 
