### PR TITLE
Task Interrupted, Syntax Error bugfixes

### DIFF
--- a/syno.plexupdate.sh
+++ b/syno.plexupdate.sh
@@ -225,10 +225,10 @@ if [ "$?" -ne "0" ]; then
   printf "%s\n" "$ChannlName Channel"                                                  >> "$SPUSFolder/Archive/Packages/changelog.new"
   printf "%s\n" ""                                                                     >> "$SPUSFolder/Archive/Packages/changelog.new"
   printf "%s\n" "New Features:"                                                        >> "$SPUSFolder/Archive/Packages/changelog.new"
-  printf "%s\n" "$NewVerAddd" | awk '{ print "* " ${BASH_SOURCE[0]} }'                 >> "$SPUSFolder/Archive/Packages/changelog.new"
+  printf "%s\n" "$NewVerAddd" | awk '{ print "* " $0 }'                                >> "$SPUSFolder/Archive/Packages/changelog.new"
   printf "%s\n" ""                                                                     >> "$SPUSFolder/Archive/Packages/changelog.new"
   printf "%s\n" "Fixed Features:"                                                      >> "$SPUSFolder/Archive/Packages/changelog.new"
-  printf "%s\n" "$NewVerFixd" | awk '{ print "* " ${BASH_SOURCE[0]} }'                 >> "$SPUSFolder/Archive/Packages/changelog.new"
+  printf "%s\n" "$NewVerFixd" | awk '{ print "* " $0 }'                                >> "$SPUSFolder/Archive/Packages/changelog.new"
   printf "%s\n" ""                                                                     >> "$SPUSFolder/Archive/Packages/changelog.new"
   printf "%s\n" "----------------------------------------"                             >> "$SPUSFolder/Archive/Packages/changelog.new"
   printf "%s\n" ""                                                                     >> "$SPUSFolder/Archive/Packages/changelog.new"
@@ -291,7 +291,7 @@ if [ "$?" -eq "0" ]; then
         # SHOW NEW PLEX FEATURES
         printf "%s\n" "NEW FEATURES:"
         printf "%s\n" "----------------------------------------"
-        printf "%s\n" "$NewVerAddd" | awk '{ print "* " ${BASH_SOURCE[0]} }'
+        printf "%s\n" "$NewVerAddd" | awk '{ print "* " $0 }'
         printf "%s\n" "----------------------------------------"
       fi
       printf "\n"
@@ -299,11 +299,11 @@ if [ "$?" -eq "0" ]; then
         # SHOW FIXED PLEX FEATURES
         printf "%s\n" "FIXED FEATURES:"
         printf "%s\n" "----------------------------------------"
-        printf "%s\n" "$NewVerFixd" | awk '{ print "* " ${BASH_SOURCE[0]} }'
+        printf "%s\n" "$NewVerFixd" | awk '{ print "* " $0 }'
         printf "%s\n" "----------------------------------------"
       fi
       /usr/syno/bin/synonotify PKGHasUpgrade '{"%PKG_HAS_UPDATE%": "Plex Media Server\n\nSyno.Plex Update task completed successfully"}'
-      ExitStatus=1
+      ExitStatus=0
     else
       printf " %s\n" "failed!"
       /usr/syno/bin/synonotify PKGHasUpgrade '{"%PKG_HAS_UPDATE%": "Plex Media Server\n\nSyno.Plex Update task failed. Installation not newer version."}'


### PR DESCRIPTION
Resolves #25.

Updated ExitStatus to articulate normal vs interrupted exit.

![image](https://user-images.githubusercontent.com/13224936/171267311-e75110bb-18aa-45de-9581-8eee8e370620.png)

![image](https://user-images.githubusercontent.com/13224936/171267327-c02951d0-0866-4740-a780-8787187b3aaf.png)

========================

Modified the awk statements to resolve the syntax error. Email notifications and the changelog text file are now populating correctly.

![image](https://user-images.githubusercontent.com/13224936/171267441-3a1da4f2-4aa2-4f6d-bf91-22475d464b88.png)


![image](https://user-images.githubusercontent.com/13224936/171267483-1d446dbc-64df-4f99-a1c6-d3923d972825.png)

========================

Made a few changes to the script file that are NOT included in the check-in for testing. You may have observed them in the provided screenshots.

Convince the script that we have an out-of-date package.
```
 RunVersion=$(/usr/syno/bin/synopkg version "PlexMediaServer")
+RunVersion="0.0.1-0000"
 RunVersion=$(echo $RunVersion | grep -oP '^.+?(?=\-)')
```

Prevent installation, but do show that we would have executed the code block
```
-      /usr/syno/bin/synopkg stop    "PlexMediaServer"
+      echo "Skippping install for testing"
+      #/usr/syno/bin/synopkg stop    "PlexMediaServer"
       printf "\n"
-      /usr/syno/bin/synopkg install "$SPUSFolder/Archive/Packages/$NewPackage"
+      #/usr/syno/bin/synopkg install "$SPUSFolder/Archive/Packages/$NewPackage"
       printf "\n"
-      /usr/syno/bin/synopkg start   "PlexMediaServer"
+      #/usr/syno/bin/synopkg start   "PlexMediaServer"
```

