### PR TITLE
Add the option to override the upgrade delay on the CLI

### DIFF
--- a/syno.plexupdate.sh
+++ b/syno.plexupdate.sh
@@ -52,6 +52,25 @@ if [ -f "$SPUSFolder/config.ini" ]; then
   . "$SPUSFolder/config.ini"
 fi
 
+# Allow an override of the timeout on the CLI
+while getopts ":a:" arg; do
+  case $arg in
+    a)
+      case $OPTARG in
+        '' | *[!0-9]*)
+          echo "The value for -a must be a number" >&2
+          ;;
+        *) MinimumAge="$OPTARG" ;;
+      esac
+      ;;
+    *)
+      echo "Missing a required argument for -${OPTARG}" >&2
+      exit 1
+      ;;
+  esac
+done
+shift $(expr $OPTIND - 1)
+
 # CHECK IF SCRIPT IS ARCHIVED
 if [ ! -d "$SPUSFolder/Archive/Scripts" ]; then
   mkdir -p "$SPUSFolder/Archive/Scripts"


### PR DESCRIPTION
I have a timed task that does this weekly, but I also want the ability
to upgrade immediately sometimes. This adds a `-a` flag that sets the
number of seconds to that number, which I can then set to zero.